### PR TITLE
Load configuration on each component individually

### DIFF
--- a/core/src/pipeless_ai/lib/config.py
+++ b/core/src/pipeless_ai/lib/config.py
@@ -87,12 +87,7 @@ class Output():
 
 class Config(metaclass=Singleton):
     def __init__(self, config):
-        # TODO: parse config file path and delete mockup config
-
-
-        # We follow a fail by default aproach. If a variable is required, it must be provided. There are no default values.
-        # A user can use a default config file and override via env vars the configuration that it needs
-
+        logger.debug('Parsing configuration')
         self._log_level = prioritized_config(config, 'log_level', f'{ENV_PREFIX}_LOG_LEVEL', required=True)
         if not self._log_level == 'INFO' and not self._log_level == 'DEBUG' and not self._log_level == 'WARN':
             logger.warning(f'Unrecognized log level: {self._log_level}. Must be INFO, WARN or DEBUG. Falling back to DEBUG')
@@ -101,6 +96,7 @@ class Config(metaclass=Singleton):
         self._input = Input(config['input'])
         self._output = Output(config['output'])
         self._n_workers = prioritized_config(config, 'n_workers', f'{ENV_PREFIX}_N_WORKERS', convert_to=int, required=True)
+        logger.debug('[green]Configuration parsed[/green]')
 
     def get_input(self):
         return self._input

--- a/core/src/pipeless_ai/lib/input/input.py
+++ b/core/src/pipeless_ai/lib/input/input.py
@@ -8,7 +8,7 @@ gi.require_version('Gst', '1.0')
 gi.require_version('GstApp', '1.0')
 from gi.repository import Gst, GstApp, GLib
 
-from pipeless_ai.lib.logger import logger, update_logger_component
+from pipeless_ai.lib.logger import logger, update_logger_component, update_logger_level
 from pipeless_ai.lib.connection import InputOutputSocket, InputPushSocket
 from pipeless_ai.lib.config import Config
 from pipeless_ai.lib.messages import EndOfStreamMsg, RgbImageMsg, StreamCapsMsg, StreamTagsMsg
@@ -125,12 +125,12 @@ def on_pad_added(element, pad, *callbacks):
     for callback in callbacks:
         callback(pad)
 
-def input():
-    # Load config
-    config = Config(None)
-    Gst.init(None)
-
+def input(config_dict):
     update_logger_component('INPUT')
+    config = Config(config_dict)
+    update_logger_level(config.get_log_level())
+
+    Gst.init(None)
 
     logger.info(f"Reading video from {config.get_input().get_video().get_uri()}")
     pipeline = Gst.Pipeline.new("pipeline")

--- a/core/src/pipeless_ai/lib/output/output.py
+++ b/core/src/pipeless_ai/lib/output/output.py
@@ -9,7 +9,7 @@ gi.require_version('GstPbutils', '1.0')
 from gi.repository import Gst, GstApp, GLib, GstPbutils
 
 from pipeless_ai.lib.connection import InputOutputSocket, OutputPullSocket
-from pipeless_ai.lib.logger import logger, update_logger_component
+from pipeless_ai.lib.logger import logger, update_logger_component, update_logger_level
 from pipeless_ai.lib.messages import EndOfStreamMsg, StreamCapsMsg, StreamTagsMsg, deserialize, RgbImageMsg
 from pipeless_ai.lib.config import Config
 
@@ -348,9 +348,12 @@ def handle_input_messages(output: Output):
 
     return True # Indicate the GLib timeout to retry on the next interval
 
-def output():
-    Gst.init(None)
+def output(config_dict):
     update_logger_component('OUTPUT')
+    config = Config(config_dict)
+    update_logger_level(config.get_log_level())
+
+    Gst.init(None)
 
     output = Output()
     loop = GLib.MainLoop()

--- a/core/src/pipeless_ai/lib/worker/worker.py
+++ b/core/src/pipeless_ai/lib/worker/worker.py
@@ -3,8 +3,9 @@ import sys
 import traceback
 import numpy as np
 
+from pipeless_ai.lib.config import Config
 from pipeless_ai.lib.connection import InputPullSocket, OutputPushSocket
-from pipeless_ai.lib.logger import logger, update_logger_component
+from pipeless_ai.lib.logger import logger, update_logger_component, update_logger_level
 from pipeless_ai.lib.messages import EndOfStreamMsg, RgbImageMsg, deserialize
 
 def fetch_and_process(user_app):
@@ -61,8 +62,10 @@ def load_user_module(path):
     user_app = UserApp()
     return user_app
 
-def worker(user_module_path):
+def worker(config_dict, user_module_path):
     update_logger_component('WORKER')
+    config = Config(config_dict)
+    update_logger_level(config.get_log_level())
 
     if not user_module_path:
         logger.error('Missing app .py file path')


### PR DESCRIPTION
By loading the configuration on each component we avoid errors on Mac OS and Windows due to the different process forking method.

Fixes #8 

