### PR TITLE
feat(core): Allow processing consecutive streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ To configure your app you can use either env vars or the config file (`config.ya
 | `worker.recv_buffer_size` | Size of the worker socket reception buffer | `300` (int) | `PIPELESS_WORKER_RECV_BUFFER_SIZE` |
 | `worker.n_workers` | Number of workers deployed | int | `PIPELESS_WORKER_N_WORKERS` |
 
+When using remote input **and** output video URIs, Pipeless will run as daemon (it will never stop) and it will process any number of consecutive streams that appear on the remote URI.
+
 ## Ready to use models
 
 We provide some modules containing a growing set of ready to use models for common cases. You can use them to develop your applications as fast as writing a couple lines of code. Each module has its own documentation, and the whole set of modules can be found [here](/models/README.md).

--- a/core/src/pipeless_ai/lib/output/output.py
+++ b/core/src/pipeless_ai/lib/output/output.py
@@ -338,8 +338,11 @@ def on_bus_message(bus: Gst.Bus, msg: Gst.Message, output: Output):
         output.remove_pipeline()
 
         config = Config(None)
-        if config.get_output().get_video().get_uri_protocol() == 'file':
-            # Stop after the first stream when using an output file
+        if (config.get_output().get_video().get_uri_protocol() == 'file'
+            or config.get_input().get_video().get_uri_protocol() == 'file'):
+            # Stop after the first stream when using an input or output file.
+            # We do not want to override the output file
+            # and we can't get a new stream once the file ends
             output.get_mainloop().quit()
     elif mtype == Gst.MessageType.ERROR:
         err, debug = msg.parse_error()
@@ -404,7 +407,7 @@ def output(config_dict):
         loop.quit()
     finally:
         logger.info('Closing pipeline')
-        # Retreive and close the sockets
+        # Retrieve and close the sockets
         m_socket.close()
         r_socket.close()
         logger.info('Output finished.')

--- a/core/src/pipeless_ai/lib/worker/worker.py
+++ b/core/src/pipeless_ai/lib/worker/worker.py
@@ -85,8 +85,11 @@ def worker(config_dict, user_module_path):
                 continue_worker = fetch_and_process(user_app)
             user_app._PipelessApp__after()
 
-            if config.get_output().get_video().get_uri_protocol() == 'file':
-               # Stop after the first stream when using an output file
+            if (config.get_output().get_video().get_uri_protocol() == 'file'
+                or config.get_input().get_video().get_uri_protocol() == 'file'):
+                # Stop after the first stream when using an input or output file.
+                # We do not want to override the output file
+                # and we can't get a new stream once the file ends
                break
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
This PR allows Pipeless to process any number of consecutive streams when using remote input and outputs. In this case Pipeless will never stop, and it will process any stream that appears on the remote URI.