### PR TITLE
feat(core): Load plugins before worker is ready

### DIFF
--- a/core/src/pipeless_ai/lib/input/input.py
+++ b/core/src/pipeless_ai/lib/input/input.py
@@ -119,7 +119,6 @@ def get_input_bin(uri):
             sys.exit(1)
 
         # Create ghost pads to be able to plug other components
-        #ghostpad_src = Gst.GhostPad.new("src", capsfilter.get_static_pad("src"))
         ghostpad_src = Gst.GhostPad.new("src", capsfilter.get_static_pad("src"))
         bin.add_pad(ghostpad_src)
 


### PR DESCRIPTION
This PR loads the plugins before the worker loop, making the `__init__` to be executed just once when loading the plugin, ideal for download stuff or performing actions to setup the plugins and the `before` to be executed before every stream.

It also handles user application errors to show them on the screen.